### PR TITLE
some basic utils needed by the tag string generation

### DIFF
--- a/lib/deas-tags.rb
+++ b/lib/deas-tags.rb
@@ -1,5 +1,5 @@
 require 'deas-tags/version'
-require 'deas-tags/tag'
+require 'deas-tags/utils'
 
 module Deas; end
 module Deas::Tags; end

--- a/lib/deas-tags/utils.rb
+++ b/lib/deas-tags/utils.rb
@@ -1,0 +1,37 @@
+module Deas; end
+module Deas::Tags
+
+  module Utils
+
+    def self.html_attrs(attrs="", ns=nil)
+      return attrs.to_s if !attrs.kind_of?(::Hash)
+
+      attrs.collect do |k_v|
+        [ns ? "#{ns}_#{k_v.first}" : k_v.first.to_s, k_v.last]
+      end.sort.collect do |k_v|
+        if k_v.last.kind_of?(::Hash)
+          html_attrs(k_v.last, k_v.first)
+        elsif k_v.last.kind_of?(::Array)
+          " #{k_v.first}=\"#{escape_attr_value(k_v.last.join(' '))}\""
+        else
+          " #{k_v.first}=\"#{escape_attr_value(k_v.last)}\""
+        end
+      end.join
+    end
+
+    ESCAPE_ATTRS = {
+      "&" => "&amp;",
+      "<" => "&lt;",
+      '"' => "&quot;"
+    }
+    ESCAPE_ATTRS_PATTERN = Regexp.union(*ESCAPE_ATTRS.keys)
+    def self.escape_attr_value(value)
+      value.to_s.gsub(ESCAPE_ATTRS_PATTERN){|c| ESCAPE_ATTRS[c] }
+    end
+
+  end
+
+  # alias for brevity
+  U = Utils
+
+end

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -1,3 +1,4 @@
+require 'deas-tags/utils'
 require 'deas-tags/tag'
 
 module Factory
@@ -7,6 +8,10 @@ module Factory
       include Deas::Tags::Tag
     end
     template_class.new
+  end
+
+  def self.html_attrs(opts)
+    Deas::Tags::Utils.html_attrs(opts)
   end
 
 end

--- a/test/unit/utils_tests.rb
+++ b/test/unit/utils_tests.rb
@@ -1,0 +1,76 @@
+require "assert"
+require 'deas-tags/utils'
+
+module Deas::Tags::Utils
+
+  class BaseTests < Assert::Context
+    desc 'Deas::Tags::Helpers'
+    subject { Deas::Tags::Utils }
+
+    should have_imeths :html_attrs, :escape_attr_value
+
+    should "alias itself as `Deas::Tags::U`" do
+      assert_same Deas::Tags::Utils, Deas::Tags::U
+    end
+
+  end
+
+  class HashAttrsTests < BaseTests
+    desc "the element class hash_attrs util"
+
+    should "convert an empty hash to element attrs" do
+      assert_equal '', subject.html_attrs({})
+    end
+
+    should "convert a basic hash to element attrs" do
+      attrs = subject.html_attrs(:class => "test", :id => "test_1")
+      assert_match /^\s{1}/, attrs
+      assert_includes 'class="test"', attrs
+      assert_includes 'id="test_1"', attrs
+
+      attrs = subject.html_attrs('key' => "string")
+      assert_includes 'key="string"', attrs
+    end
+
+    should "escape double-quotes in attr values" do
+      attrs = subject.html_attrs('escaped' => '"this" is double-quoted')
+      assert_includes 'escaped="&quot;this&quot; is double-quoted"', attrs
+    end
+
+    should "escape '<' in attr values" do
+      attrs = subject.html_attrs('escaped' => 'not < escaped')
+      assert_includes 'escaped="not &lt; escaped"', attrs
+    end
+
+    should "escape '&' in attr values" do
+      attrs = subject.html_attrs('escaped' => 'not & escaped')
+      assert_includes 'escaped="not &amp; escaped"', attrs
+    end
+
+    should "convert a nested array to element attrs" do
+      attrs = subject.html_attrs({
+        :class => "testing",
+        :id => "test_2",
+        :nested => [:something, 'is_awesome', 1]
+      })
+      assert_match /^\s{1}/, attrs
+      assert_included 'class="testing"', attrs
+      assert_included 'id="test_2"', attrs
+      assert_included 'nested="something is_awesome 1"', attrs
+    end
+
+    should "convert a nested hash to element attrs" do
+      attrs = subject.html_attrs({
+        :class => "testing",
+        :id => "test_2",
+        :nested => {:something => 'is_awesome'}
+      })
+      assert_match /^\s{1}/, attrs
+      assert_included 'class="testing"', attrs
+      assert_included 'id="test_2"', attrs
+      assert_included 'nested_something="is_awesome"', attrs
+    end
+
+  end
+
+end


### PR DESCRIPTION
These will be used to render the tag string in the base `tag` method.
I put them into their own module as class methods b/c they shouldn't
be mixed in as a template helper - they are just singleton utils.

`escape_attr_value` escapes html attribute values so they can safely
be added to the tag markup string.

`html_attrs` takes a hash and converts it to a string of html attributes,
accounting for nexted arrays and hashes.

@jcredding this is a rip from https://github.com/kellyredding/undies/blob/master/lib/undies/element.rb#L10, doing the same thing they did there.  ready for review.
