### PR TITLE
basic `tag` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# DeasTags
+# Deas::Tags
 
 Template helpers for creating basic html tags.
 
@@ -26,7 +26,12 @@ end
 
 ## Tags
 
-TODO: talk about basic `tag` method
+All helpers are based off of the basic `tag` helper:
+
+```ruby
+tag(:br)                             # => <br />
+tag(:h1, 'shizam', :title => "boom") # => <h1 title="boom">shizam</h1>
+```
 
 ### LinkTo
 

--- a/lib/deas-tags/tag.rb
+++ b/lib/deas-tags/tag.rb
@@ -1,0 +1,19 @@
+require 'deas-tags/utils'
+
+module Deas::Tags
+
+  module Tag
+
+    def tag(name, *args)
+      opts, content = [
+        args.last.kind_of?(::Hash) ? args.pop : {},
+        args.first
+      ]
+      attrs = U.html_attrs(opts)
+
+      "<#{name}#{attrs}#{content ? ">#{content}</#{name}" : ' /'}>"
+    end
+
+  end
+
+end

--- a/test/unit/tag_tests.rb
+++ b/test/unit/tag_tests.rb
@@ -1,0 +1,38 @@
+require 'assert'
+require 'deas-tags/tag'
+
+module Deas::Tags::Tag
+
+  class BaseTests < Assert::Context
+    desc "the basic tag method"
+    setup do
+      @opts = { :class => 'big', :id => '1234' }
+      @content = "Loud Noises"
+      @opts_attrs = Factory.html_attrs(@opts)
+      @template = Factory.tags_template
+    end
+    subject{ @template }
+
+    should have_imeth :tag
+
+    should "create an empty html tag" do
+      assert_equal "<br />", @template.tag(:br)
+    end
+
+    should "create an html tag with attributes" do
+      assert_equal "<br#{@opts_attrs} />", @template.tag(:br, @opts)
+    end
+
+    should "create an html tag with content" do
+      exp_markup = "<h1>#{@content}</h1>"
+      assert_equal exp_markup, @template.tag(:h1, @content)
+    end
+
+    should "create an html tag with attributes and content" do
+      exp_markup = "<h1#{@opts_attrs}>#{@content}</h1>"
+      assert_equal exp_markup, @template.tag(:h1, @content, @opts)
+    end
+
+  end
+
+end


### PR DESCRIPTION
This is the base method all other tag methods will be built off of.
It takes a name and some optional content and options.  The content
is nested if present and the options are converted to an html attrs
string.

This is the most basic way to generate a tag and all future tag methods
will just be macros that in some way build/provide arguments to call
this method with.  This is the base of all the things.

@jcredding ready for review.
