### PR TITLE
rename to 'deas-erbtags'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,23 @@
-# Deas::Tags
+# Deas::ErbTags
 
-Template helpers for creating basic html tags.
+Template helpers for creating html tags using Erb (or Erubis, etc).
 
 ## Usage
 
 ```ruby
-require 'deas-tags'
+require 'deas-erbtags'
 
 class MyDeasServer
   include Deas::Server
 
   # ...
 
-  template_helpers(Deas::Tags) # include them all
+  template_helpers(Deas::ErbTags) # include them all
 
   # OR just include some...
 
-  template_helpers(Deas::Tags::LinkTo)
-  template_helpers(Deas::Tags::ImageTag)
+  template_helpers(Deas::ErbTags::LinkTo)
+  template_helpers(Deas::ErbTags::ImageTag)
 
   # ...
 
@@ -53,7 +53,7 @@ TODO
 
 Add this line to your application's Gemfile:
 
-    gem 'deas-tags'
+    gem 'deas-erbtags'
 
 And then execute:
 
@@ -61,7 +61,7 @@ And then execute:
 
 Or install it yourself as:
 
-    $ gem install deas-tags
+    $ gem install deas-erbtags
 
 ## Contributing
 

--- a/deas-tags.gemspec
+++ b/deas-tags.gemspec
@@ -1,16 +1,16 @@
 # -*- encoding: utf-8 -*-
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require "deas-tags/version"
+require "deas-erbtags/version"
 
 Gem::Specification.new do |gem|
-  gem.name        = "deas-tags"
-  gem.version     = Deas::Tags::VERSION
+  gem.name        = "deas-erbtags"
+  gem.version     = Deas::ErbTags::VERSION
   gem.authors     = ["Kelly Redding", "Collin Redding"]
   gem.email       = ["kelly@kellyredding.com", "collin.redding@me.com"]
-  gem.description = %q{Deas template helpers for creating common HTML tags}
-  gem.summary     = %q{Deas template helpers for creating common HTML tags}
-  gem.homepage    = "http://github.com/redding/deas-tags"
+  gem.description = %q{Deas template helpers for creating HTML tags using Erb.}
+  gem.summary     = %q{Deas template helpers for creating HTML tags using Erb.}
+  gem.homepage    = "http://github.com/redding/deas-erbtags"
 
   gem.files         = `git ls-files`.split($/)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }

--- a/lib/deas-erbtags.rb
+++ b/lib/deas-erbtags.rb
@@ -1,0 +1,5 @@
+require 'deas-erbtags/version'
+require 'deas-erbtags/utils'
+
+module Deas; end
+module Deas::ErbTags; end

--- a/lib/deas-erbtags/tag.rb
+++ b/lib/deas-erbtags/tag.rb
@@ -1,6 +1,6 @@
-require 'deas-tags/utils'
+require 'deas-erbtags/utils'
 
-module Deas::Tags
+module Deas::ErbTags
 
   module Tag
 

--- a/lib/deas-erbtags/utils.rb
+++ b/lib/deas-erbtags/utils.rb
@@ -1,5 +1,5 @@
 module Deas; end
-module Deas::Tags
+module Deas::ErbTags
 
   module Utils
 

--- a/lib/deas-erbtags/version.rb
+++ b/lib/deas-erbtags/version.rb
@@ -1,4 +1,4 @@
 module Deas; end
-module Deas::Tags
+module Deas::ErbTags
   VERSION = "0.0.1"
 end

--- a/lib/deas-tags.rb
+++ b/lib/deas-tags.rb
@@ -1,5 +1,0 @@
-require 'deas-tags/version'
-require 'deas-tags/utils'
-
-module Deas; end
-module Deas::Tags; end

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -1,17 +1,17 @@
-require 'deas-tags/utils'
-require 'deas-tags/tag'
+require 'deas-erbtags/utils'
+require 'deas-erbtags/tag'
 
 module Factory
 
   def self.tags_template
     template_class = Class.new do
-      include Deas::Tags::Tag
+      include Deas::ErbTags::Tag
     end
     template_class.new
   end
 
   def self.html_attrs(opts)
-    Deas::Tags::Utils.html_attrs(opts)
+    Deas::ErbTags::Utils.html_attrs(opts)
   end
 
 end

--- a/test/unit/tag_tests.rb
+++ b/test/unit/tag_tests.rb
@@ -1,7 +1,7 @@
 require 'assert'
-require 'deas-tags/tag'
+require 'deas-erbtags/tag'
 
-module Deas::Tags::Tag
+module Deas::ErbTags::Tag
 
   class BaseTests < Assert::Context
     desc "the basic tag method"

--- a/test/unit/utils_tests.rb
+++ b/test/unit/utils_tests.rb
@@ -1,16 +1,16 @@
 require "assert"
-require 'deas-tags/utils'
+require 'deas-erbtags/utils'
 
-module Deas::Tags::Utils
+module Deas::ErbTags::Utils
 
   class BaseTests < Assert::Context
-    desc 'Deas::Tags::Helpers'
-    subject { Deas::Tags::Utils }
+    desc 'Deas::ErbTags::Helpers'
+    subject { Deas::ErbTags::Utils }
 
     should have_imeths :html_attrs, :escape_attr_value
 
-    should "alias itself as `Deas::Tags::U`" do
-      assert_same Deas::Tags::Utils, Deas::Tags::U
+    should "alias itself as `Deas::ErbTags::U`" do
+      assert_same Deas::ErbTags::Utils, Deas::ErbTags::U
     end
 
   end


### PR DESCRIPTION
This is in prep for adding erb-specific behavior.  Specifically the
future `capture_tag` method for capturing content from a template
block.

If we are good with this, I'll also rename the repo on Github.

@jcredding ready for review.
