### PR TITLE
implementing the "include them all" behavior of Deas::ErbTags module

### DIFF
--- a/lib/deas-erbtags.rb
+++ b/lib/deas-erbtags.rb
@@ -1,5 +1,17 @@
 require 'deas-erbtags/version'
 require 'deas-erbtags/utils'
 
+require 'deas-erbtags/tag'
+
 module Deas; end
-module Deas::ErbTags; end
+module Deas::ErbTags
+
+  # this implements the "include them all" behavior
+
+  def self.included(receiver)
+    receiver.class_eval do
+      include Tag
+    end
+  end
+
+end

--- a/lib/deas-erbtags/tag.rb
+++ b/lib/deas-erbtags/tag.rb
@@ -1,7 +1,6 @@
 require 'deas-erbtags/utils'
 
 module Deas::ErbTags
-
   module Tag
 
     def tag(name, *args)
@@ -15,5 +14,4 @@ module Deas::ErbTags
     end
 
   end
-
 end

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -3,9 +3,9 @@ require 'deas-erbtags/tag'
 
 module Factory
 
-  def self.tags_template
+  def self.template(*included_modules)
     template_class = Class.new do
-      include Deas::ErbTags::Tag
+      include *included_modules
     end
     template_class.new
   end

--- a/test/unit/deas-erbtags_tests.rb
+++ b/test/unit/deas-erbtags_tests.rb
@@ -1,0 +1,27 @@
+require 'assert'
+require 'deas-erbtags'
+
+module Deas::ErbTags
+
+  class BaseTests < Assert::Context
+    desc "Deas::ErbTags"
+    setup do
+      @template = Factory.template(Deas::ErbTags)
+    end
+    subject{ @template }
+
+    should have_imeths :tag
+
+    should "include all of the individual modules" do
+      exp_modules = [
+        Tag
+      ]
+
+      exp_modules.each do |m|
+        assert_includes m, subject.class.included_modules
+      end
+    end
+
+  end
+
+end

--- a/test/unit/tag_tests.rb
+++ b/test/unit/tag_tests.rb
@@ -9,7 +9,7 @@ module Deas::ErbTags::Tag
       @opts = { :class => 'big', :id => '1234' }
       @content = "Loud Noises"
       @opts_attrs = Factory.html_attrs(@opts)
-      @template = Factory.tags_template
+      @template = Factory.template(Deas::ErbTags::Tag)
     end
     subject{ @template }
 


### PR DESCRIPTION
If this is added as a template helper (included), it should include
_every_ tag module as well.

@jcredding ready for review.
