### PR TITLE
`link_to` tag method for creating anchor tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,12 @@ tag(:h1, 'shizam', :title => "boom") # => <h1 title="boom">shizam</h1>
 
 **Note**: all tag methods take an option hash of html attributes (like above).  This use-case is assumed in the examples below.
 
-### LinkTo
+### `link_to`
 
-TODO
+```ruby
+link_to "http://google.com"           # => <a href="http://google.com">http://google.com</a>
+link_to "google", "http://google.com" # => <a href="http://google.com">google</a>
+```
 
 ### MailTo
 

--- a/lib/deas-erbtags.rb
+++ b/lib/deas-erbtags.rb
@@ -2,6 +2,7 @@ require 'deas-erbtags/version'
 require 'deas-erbtags/utils'
 
 require 'deas-erbtags/tag'
+require 'deas-erbtags/link_to'
 
 module Deas; end
 module Deas::ErbTags
@@ -10,7 +11,7 @@ module Deas::ErbTags
 
   def self.included(receiver)
     receiver.class_eval do
-      include Tag
+      include Tag, LinkTo
     end
   end
 

--- a/lib/deas-erbtags/link_to.rb
+++ b/lib/deas-erbtags/link_to.rb
@@ -1,0 +1,27 @@
+require 'deas-erbtags/tag'
+
+module Deas::ErbTags
+  module LinkTo
+
+    def self.included(receiver)
+      receiver.class_eval{ include Tag, Method }
+    end
+
+    module Method
+
+      def link_to(*args)
+        opts, href, content = [
+          args.last.kind_of?(::Hash) ? args.pop : {},
+          args.pop,
+          args.last
+        ]
+        opts.update(:href => href.to_s) if !href.nil?
+        content ||= href
+
+        tag(:a, content, opts)
+      end
+
+    end
+
+  end
+end

--- a/test/unit/deas-erbtags_tests.rb
+++ b/test/unit/deas-erbtags_tests.rb
@@ -10,11 +10,11 @@ module Deas::ErbTags
     end
     subject{ @template }
 
-    should have_imeths :tag
+    should have_imeths :tag, :link_to
 
     should "include all of the individual modules" do
       exp_modules = [
-        Tag
+        Tag, LinkTo
       ]
 
       exp_modules.each do |m|

--- a/test/unit/link_to_tests.rb
+++ b/test/unit/link_to_tests.rb
@@ -1,0 +1,48 @@
+require 'assert'
+require 'deas-erbtags/tag'
+require 'deas-erbtags/link_to'
+
+module Deas::ErbTags::LinkTo
+
+  class BaseTests < Assert::Context
+    desc "the `LinkTo` module"
+    setup do
+      @template = Factory.template(Deas::ErbTags::LinkTo)
+    end
+    subject{ @template }
+
+    should have_imeth :link_to
+
+    should "include the `Tag` module" do
+      assert_includes Deas::ErbTags::Tag, subject.class.included_modules
+    end
+
+    should "create an anchor tag with no content or href" do
+      no_href_content = subject.tag(:a)
+      assert_equal no_href_content, subject.link_to
+    end
+
+    should "create an anchor tag with just an href" do
+      href = subject.tag(:a, 'www.google.com', {:href => 'www.google.com'})
+      assert_equal href, subject.link_to('www.google.com')
+    end
+
+    should "create an anchor tag with an href and content" do
+      href_content = subject.tag(:a, 'google', {:href => 'www.google.com'})
+      assert_equal href_content, subject.link_to('google', 'www.google.com')
+    end
+
+    should "create an anchor tag with an href, content, and attrs" do
+      href_content_opts = subject.tag(:a, 'google', {
+        :href => 'www.google.com',
+        :id => 'google_link'
+      })
+      link_to = subject.link_to('google', 'www.google.com', {
+        :id => 'google_link'
+      })
+      assert_equal href_content_opts, link_to
+    end
+
+  end
+
+end


### PR DESCRIPTION
Uses the base `tag` method to create anchor tags easily.  Flexible
arguments and intelligent defaults allow you to specify as much or
as little data necessary to creat the tag.

See the README for usage details.

@jcredding ready for review.
