### PR TITLE
`mail_to` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ end
 
 ## Tags
 
-All helpers are based off of the basic `tag` helper:
+All helpers are based off of the basic `tag` method:
 
 ```ruby
 tag(:br)                             # => <br />
@@ -42,14 +42,23 @@ link_to "http://google.com"           # => <a href="http://google.com">http://go
 link_to "google", "http://google.com" # => <a href="http://google.com">google</a>
 ```
 
-### MailTo
+### `mail_to`
 
-TODO
+```ruby
+mail_to "me@domain.com"
+  # => <a href="mailto:me@domain.com">me@domain.com</a>
+
+mail_to "me@domain.com", :at => "_at_", :dot => "_dot_"
+  # => <a href="mailto:me@domain.com">me_at_domain_dot_com</a>
+
+mail_to "me@domain.com", :disabled => true
+  # => me@domain.com
+```
 
 ### `image_tag`
 
 ```ruby
-image_tag '/logo.jpg'   #  => <img src="/logo.jpg" />
+image_tag '/logo.jpg'  #  => <img src="/logo.jpg" />
 ```
 
 ### FormTags

--- a/lib/deas-erbtags.rb
+++ b/lib/deas-erbtags.rb
@@ -3,6 +3,7 @@ require 'deas-erbtags/utils'
 
 require 'deas-erbtags/tag'
 require 'deas-erbtags/link_to'
+require 'deas-erbtags/mail_to'
 require 'deas-erbtags/image_tag'
 
 module Deas; end
@@ -12,7 +13,7 @@ module Deas::ErbTags
 
   def self.included(receiver)
     receiver.class_eval do
-      include Tag, LinkTo, ImageTag
+      include Tag, LinkTo, MailTo, ImageTag
     end
   end
 

--- a/lib/deas-erbtags/mail_to.rb
+++ b/lib/deas-erbtags/mail_to.rb
@@ -1,0 +1,30 @@
+require 'deas-erbtags/tag'
+require 'deas-erbtags/link_to'
+
+module Deas::ErbTags
+  module MailTo
+
+    def self.included(receiver)
+      receiver.class_eval{ include Tag, LinkTo, Method }
+    end
+
+    module Method
+
+      def mail_to(*args)
+        opts, email, content = [
+          args.last.kind_of?(::Hash) ? args.pop : {},
+          args.pop,
+          args.last
+        ]
+        display = (content || email).dup
+        display.gsub!(/@/, opts.delete(:at)) if opts.has_key?(:at)
+        display.gsub!(/\./, opts.delete(:dot)) if opts.has_key?(:dot)
+
+        return display if opts.delete(:disabled)
+        link_to(display, "mailto: #{email}", opts)
+      end
+
+    end
+
+  end
+end

--- a/test/unit/deas-erbtags_tests.rb
+++ b/test/unit/deas-erbtags_tests.rb
@@ -10,11 +10,11 @@ module Deas::ErbTags
     end
     subject{ @template }
 
-    should have_imeths :tag, :link_to, :image_tag
+    should have_imeths :tag, :link_to, :mail_to, :image_tag
 
     should "include all of the individual modules" do
       exp_modules = [
-        Tag, LinkTo, ImageTag
+        Tag, LinkTo, MailTo, ImageTag
       ]
 
       exp_modules.each do |m|

--- a/test/unit/mail_to_tests.rb
+++ b/test/unit/mail_to_tests.rb
@@ -1,0 +1,51 @@
+require 'assert'
+require 'deas-erbtags/tag'
+require 'deas-erbtags/link_to'
+require 'deas-erbtags/mail_to'
+
+module Deas::ErbTags::MailTo
+
+  class BaseTests < Assert::Context
+    desc "the `MailTo` module"
+    setup do
+      @link_content = "my email"
+      @email = "me@domain.com"
+      @template = Factory.template(Deas::ErbTags::MailTo)
+    end
+    subject{ @template }
+
+    should have_imeth :mail_to
+
+    should "include the `Tag` module" do
+      assert_includes Deas::ErbTags::Tag, subject.class.included_modules
+    end
+
+    should "include the `LinkTo` module" do
+      assert_includes Deas::ErbTags::LinkTo, subject.class.included_modules
+    end
+
+    should "render with just an email address" do
+      link_tag = subject.link_to(@email, "mailto: #{@email}")
+      assert_equal link_tag, subject.mail_to(@email)
+    end
+
+    should "render with custom display value" do
+      link_tag = subject.link_to(@link_content, "mailto: #{@email}")
+      assert_equal link_tag, subject.mail_to(@link_content, @email)
+    end
+
+    should "render obfuscating the email address displayed" do
+      obfus = "me_at_domain_dot_com"
+      link_tag = subject.link_to(obfus, "mailto: #{@email}")
+      mailto = subject.mail_to(@email, :at => "_at_", :dot => "_dot_")
+
+      assert_equal link_tag, mailto
+    end
+
+    should "render with link disabled" do
+      assert_equal @email, subject.mail_to(@email, :disabled => true)
+    end
+
+  end
+
+end


### PR DESCRIPTION
Creates anchor tags for composing email to a given address.  Has
some options for disabling and obfuscating displayed addresses.

@jcredding ready for review.

Closes #13 
