### PR TITLE
`capture_tag` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,16 +24,29 @@ class MyDeasServer
 end
 ```
 
-## Tags
+## Methods
 
-All helpers are based off of the basic `tag` method:
+All helper methods are based off of the basic `tag` method.  Tag calls should be invoked with `<%= ... -%>`:
 
-```ruby
-tag(:br)                             # => <br />
-tag(:h1, 'shizam', :title => "boom") # => <h1 title="boom">shizam</h1>
+```erb
+<%= tag(:br) -%>                             # => <br />
+<%= tag(:h1, 'shizam', :title => "boom") -%> # => <h1 title="boom">shizam</h1>
 ```
 
 **Note**: all tag methods take an option hash of html attributes (like above).  This use-case is assumed in the examples below.
+
+### `capture_tag`
+
+The `capture_tag` method is used to create tags with nested erb markup.  Like the `tag` method, it creates other tags with a similar API.  Unlike the `tag` method, it takes a block that contains nested markup and does not take content as an arg.  Capture tags should be invoked with the `<% ... %>`:
+
+```erb
+<% content_tag(:div, :id => 'outer') do %>
+  <%= tag(:div, 'inner') -%>
+<% end %>
+  # => <div id="outer">\n  <div>inner</div>\n</div>\n
+```
+
+**Note**: the convention is that if a tag method is called with a block, `capture_tag` will be used to generate the tag and it should be invoked with `<% ... %>`.
 
 ### `link_to`
 

--- a/lib/deas-erbtags.rb
+++ b/lib/deas-erbtags.rb
@@ -2,6 +2,7 @@ require 'deas-erbtags/version'
 require 'deas-erbtags/utils'
 
 require 'deas-erbtags/tag'
+require 'deas-erbtags/capture_tag'
 require 'deas-erbtags/link_to'
 require 'deas-erbtags/mail_to'
 require 'deas-erbtags/image_tag'
@@ -13,7 +14,7 @@ module Deas::ErbTags
 
   def self.included(receiver)
     receiver.class_eval do
-      include Tag, LinkTo, MailTo, ImageTag
+      include Tag, CaptureTag, LinkTo, MailTo, ImageTag
     end
   end
 

--- a/lib/deas-erbtags/capture_tag.rb
+++ b/lib/deas-erbtags/capture_tag.rb
@@ -1,0 +1,37 @@
+require 'deas-erbtags/tag'
+
+module Deas::ErbTags
+  module CaptureTag
+
+    def self.included(receiver)
+      receiver.class_eval{ include Tag, Method }
+    end
+
+    module Method
+
+      def capture_tag(name, *args)
+        opts = args.last.kind_of?(::Hash) ? args.pop : {}
+        outvar = self.sinatra_call.settings.erb[:outvar]
+        captured_content = begin
+          orig_outvar = instance_variable_get(outvar)
+          instance_variable_set(outvar, "\n")
+
+          result = yield if block_given?
+
+          if instance_variable_get(outvar) == "\n"
+            "\n#{result}"
+          else
+            instance_variable_get(outvar)
+          end
+        ensure
+          instance_variable_set(outvar, orig_outvar)
+        end
+
+        tag_markup = tag(name, "#{captured_content}\n", opts)
+        instance_variable_get(outvar) << "#{tag_markup}\n"
+      end
+
+    end
+
+  end
+end

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -1,3 +1,4 @@
+require 'ostruct'
 require 'deas-erbtags/utils'
 require 'deas-erbtags/tag'
 
@@ -6,7 +7,22 @@ module Factory
   def self.template(*included_modules)
     template_class = Class.new do
       include *included_modules
+
+      attr_reader :_out_buf
+      def initialize
+        @_out_buf = ""
+      end
+
+      # he expected API for the Deas template scope to access erb settings
+      def sinatra_call
+        OpenStruct.new({
+          :settings => OpenStruct.new({
+            :erb => { :outvar => '@_out_buf' }
+          })
+        })
+      end
     end
+
     template_class.new
   end
 

--- a/test/unit/capture_tag_tests.rb
+++ b/test/unit/capture_tag_tests.rb
@@ -1,0 +1,49 @@
+require 'assert'
+require 'deas-erbtags/tag'
+require 'deas-erbtags/capture_tag'
+
+module Deas::ErbTags::CaptureTag
+
+  class BaseTests < Assert::Context
+    desc "the `CaptureTag` module"
+    setup do
+      @template = Factory.template(Deas::ErbTags::CaptureTag)
+    end
+    subject{ @template }
+
+    should have_imeth :capture_tag
+
+    should "include the `Tag` module" do
+      assert_includes Deas::ErbTags::Tag, subject.class.included_modules
+    end
+
+    should "create content by capturing content from a given block" do
+      div_div = subject.tag(:div, "\n#{subject.tag(:div, "\ninner\n")}\n\n", {
+        :id => 'outer'
+      }) + "\n"
+      buf_content_div = subject.capture_tag(:div, :id => 'outer') do
+        subject.capture_tag(:div){ subject._out_buf << 'inner' }
+      end
+
+      assert_equal div_div, buf_content_div
+    end
+
+    should "create content by returning content from a given block" do
+      div_div = subject.tag(:div, "\n#{subject.tag(:div, "\ninner\n")}\n\n", {
+        :id => 'outer'
+      }) + "\n"
+      returned_content_div = subject.capture_tag(:div, :id => 'outer') do
+        subject.capture_tag(:div){ 'inner' }
+      end
+
+      assert_equal div_div, returned_content_div
+    end
+
+    should "create empty tags if no block given" do
+      empty_div = subject.tag(:div, "\n\n", :id => 'outer') + "\n"
+      assert_equal empty_div, subject.capture_tag(:div, :id => 'outer')
+    end
+
+  end
+
+end

--- a/test/unit/deas-erbtags_tests.rb
+++ b/test/unit/deas-erbtags_tests.rb
@@ -14,7 +14,7 @@ module Deas::ErbTags
 
     should "include all of the individual modules" do
       exp_modules = [
-        Tag, LinkTo, MailTo, ImageTag
+        Tag, CaptureTag, LinkTo, MailTo, ImageTag
       ]
 
       exp_modules.each do |m|


### PR DESCRIPTION
This method is used to create tags with nested erb markup.  Like the
`tag` method, it creates other tags with a similar API.

Unlike the `tag` method, it takes a block that contains nested markup
and does not take content as an arg.  Capture tags should be invoked
with the `<% ... %>`.

Closes #12.

@jcredding ready for review.
