### PR TITLE
capture content if `link_to` called with a content block

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,14 @@ The `capture_tag` method is used to create tags with nested erb markup.  Like th
 ### `link_to`
 
 ```ruby
-link_to "http://google.com"           # => <a href="http://google.com">http://google.com</a>
-link_to "google", "http://google.com" # => <a href="http://google.com">google</a>
+link_to "http://google.com"
+  # => <a href="http://google.com">http://google.com</a>
+
+link_to "google", "http://google.com"
+  # => <a href="http://google.com">google</a>
+
+link_to("http://google.com"){ tag(:span, 'google') }
+  # => <a href="http://google.com">\n<span>google</span>\n</a>\n
 ```
 
 ### `mail_to`

--- a/lib/deas-erbtags/link_to.rb
+++ b/lib/deas-erbtags/link_to.rb
@@ -1,24 +1,28 @@
 require 'deas-erbtags/tag'
+require 'deas-erbtags/capture_tag'
 
 module Deas::ErbTags
   module LinkTo
 
     def self.included(receiver)
-      receiver.class_eval{ include Tag, Method }
+      receiver.class_eval{ include Tag, CaptureTag, Method }
     end
 
     module Method
 
-      def link_to(*args)
+      def link_to(*args, &block)
         opts, href, content = [
           args.last.kind_of?(::Hash) ? args.pop : {},
           args.pop,
           args.last
         ]
         opts.update(:href => href.to_s) if !href.nil?
-        content ||= href
 
-        tag(:a, content, opts)
+        if block_given?
+          capture_tag(:a, opts, &block)
+        else
+          tag(:a, content || href, opts)
+        end
       end
 
     end

--- a/test/unit/link_to_tests.rb
+++ b/test/unit/link_to_tests.rb
@@ -1,5 +1,6 @@
 require 'assert'
 require 'deas-erbtags/tag'
+require 'deas-erbtags/capture_tag'
 require 'deas-erbtags/link_to'
 
 module Deas::ErbTags::LinkTo
@@ -15,6 +16,10 @@ module Deas::ErbTags::LinkTo
 
     should "include the `Tag` module" do
       assert_includes Deas::ErbTags::Tag, subject.class.included_modules
+    end
+
+    should "include the `CaptureTag` module" do
+      assert_includes Deas::ErbTags::CaptureTag, subject.class.included_modules
     end
 
     should "create an anchor tag with no content or href" do
@@ -41,6 +46,13 @@ module Deas::ErbTags::LinkTo
         :id => 'google_link'
       })
       assert_equal href_content_opts, link_to
+    end
+
+    should "create an anchor tag with an href and captured content" do
+      span = subject.tag(:span, 'google')
+      exp = subject.tag(:a, "\n#{span}\n", {:href => 'www.google.com'}) + "\n"
+
+      assert_equal exp, subject.link_to('www.google.com'){ span }
     end
 
   end


### PR DESCRIPTION
This tests and if a block is given, it is assumed the `link_to` is
a `capture_tag`.  The block will be called any any output captured.
Use this to nest erb in a `link_to`.

Closes #2.

@jcredding ready for review.
