### PR TITLE
be sure to `instance_eval` the content block when capturing

### DIFF
--- a/lib/deas-erbtags/capture_tag.rb
+++ b/lib/deas-erbtags/capture_tag.rb
@@ -9,14 +9,14 @@ module Deas::ErbTags
 
     module Method
 
-      def capture_tag(name, *args)
+      def capture_tag(name, *args, &content)
         opts = args.last.kind_of?(::Hash) ? args.pop : {}
         outvar = self.sinatra_call.settings.erb[:outvar]
         captured_content = begin
           orig_outvar = instance_variable_get(outvar)
           instance_variable_set(outvar, "\n")
 
-          result = yield if block_given?
+          result = instance_eval(&content) if !content.nil?
 
           if instance_variable_get(outvar) == "\n"
             "\n#{result}"

--- a/test/unit/capture_tag_tests.rb
+++ b/test/unit/capture_tag_tests.rb
@@ -22,18 +22,18 @@ module Deas::ErbTags::CaptureTag
         :id => 'outer'
       }) + "\n"
       buf_content_div = subject.capture_tag(:div, :id => 'outer') do
-        subject.capture_tag(:div){ subject._out_buf << 'inner' }
+        capture_tag(:div){ 'inner' }
       end
 
       assert_equal div_div, buf_content_div
     end
 
     should "create content by returning content from a given block" do
-      div_div = subject.tag(:div, "\n#{subject.tag(:div, "\ninner\n")}\n\n", {
+      div_div = subject.tag(:div, "\n#{subject.tag(:div, "inner")}\n", {
         :id => 'outer'
       }) + "\n"
       returned_content_div = subject.capture_tag(:div, :id => 'outer') do
-        subject.capture_tag(:div){ 'inner' }
+        tag(:div, 'inner')
       end
 
       assert_equal div_div, returned_content_div


### PR DESCRIPTION
This ensures the current binding is always used - not whatever binding
the content came from.  Without this, content gets added to the
wrong buffer at the wrong time.

@jcredding ready for review.
