### PR TITLE
Capture handling improvemements

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ end
 
 ## Methods
 
+```ruby
+template_helpers(Deas::ErbTags::Tag)
+```
+
 All helper methods are based off of the basic `tag` method.  Tag calls should be invoked with `<%= ... -%>`:
 
 ```erb
@@ -36,6 +40,10 @@ All helper methods are based off of the basic `tag` method.  Tag calls should be
 **Note**: all tag methods take an option hash of html attributes (like above).  This use-case is assumed in the examples below.
 
 ### `capture_tag`
+
+```ruby
+template_helpers(Deas::ErbTags::Capture)
+```
 
 The `capture_tag` method is used to create tags with nested erb markup.  Like the `tag` method, it creates other tags with a similar API.  Unlike the `tag` method, it takes a block that contains nested markup and does not take content as an arg.  Capture tags should be invoked with the `<% ... %>`:
 
@@ -48,9 +56,27 @@ The `capture_tag` method is used to create tags with nested erb markup.  Like th
 
 **Note**: the convention is that if a tag method is called with a block, `capture_tag` will be used to generate the tag and it should be invoked with `<% ... %>`.
 
+### `capture_render`
+
+```ruby
+template_helpers(Deas::ErbTags::Capture)
+```
+
+The `capture_render` method is used to make Deas template `render` calls with nested erb markup.  It calls `render` with the given args, and captures its output.  Call it just as you would `render`, just invoke the call using `<% ... %>`.
+
+### `capture_render`
+
+```ruby
+template_helpers(Deas::ErbTags::Capture)
+```
+
+The `capture_partial` method is used to make Deas template `partial` calls with nested erb markup.  It calls `partial` with the given args, and captures its output.  Call it just as you would `partial`, just invoke the call using `<% ... %>`.
+
 ### `link_to`
 
 ```ruby
+template_helpers(Deas::ErbTags::LinkTo)
+
 link_to "http://google.com"
   # => <a href="http://google.com">http://google.com</a>
 
@@ -64,6 +90,8 @@ link_to("http://google.com"){ tag(:span, 'google') }
 ### `mail_to`
 
 ```ruby
+template_helpers(Deas::ErbTags::MailTo)
+
 mail_to "me@domain.com"
   # => <a href="mailto:me@domain.com">me@domain.com</a>
 
@@ -77,6 +105,8 @@ mail_to "me@domain.com", :disabled => true
 ### `image_tag`
 
 ```ruby
+template_helpers(Deas::ErbTags::ImageTag)
+
 image_tag '/logo.jpg'  #  => <img src="/logo.jpg" />
 ```
 

--- a/lib/deas-erbtags.rb
+++ b/lib/deas-erbtags.rb
@@ -2,7 +2,7 @@ require 'deas-erbtags/version'
 require 'deas-erbtags/utils'
 
 require 'deas-erbtags/tag'
-require 'deas-erbtags/capture_tag'
+require 'deas-erbtags/capture'
 require 'deas-erbtags/link_to'
 require 'deas-erbtags/mail_to'
 require 'deas-erbtags/image_tag'
@@ -14,7 +14,7 @@ module Deas::ErbTags
 
   def self.included(receiver)
     receiver.class_eval do
-      include Tag, CaptureTag, LinkTo, MailTo, ImageTag
+      include Tag, Capture, LinkTo, MailTo, ImageTag
     end
   end
 

--- a/lib/deas-erbtags/capture.rb
+++ b/lib/deas-erbtags/capture.rb
@@ -42,6 +42,10 @@ module Deas::ErbTags
         self.capture tag(name, "#{captured_content}\n", opts)
       end
 
+      def capture_render(*args, &block)
+        self.capture self.render(*args, &block)
+      end
+
     end
 
   end

--- a/lib/deas-erbtags/capture.rb
+++ b/lib/deas-erbtags/capture.rb
@@ -46,6 +46,10 @@ module Deas::ErbTags
         self.capture self.render(*args, &block)
       end
 
+      def capture_partial(*args, &block)
+        self.capture self.partial(*args, &block)
+      end
+
     end
 
   end

--- a/lib/deas-erbtags/capture.rb
+++ b/lib/deas-erbtags/capture.rb
@@ -1,7 +1,7 @@
 require 'deas-erbtags/tag'
 
 module Deas::ErbTags
-  module CaptureTag
+  module Capture
 
     def self.included(receiver)
       receiver.class_eval{ include Tag, Methods }

--- a/lib/deas-erbtags/capture.rb
+++ b/lib/deas-erbtags/capture.rb
@@ -17,6 +17,10 @@ module Deas::ErbTags
         instance_variable_get(self.erb_outvar_name)
       end
 
+      def capture(content)
+        self.erb_outvar << "#{content}\n"
+      end
+
       def capture_tag(name, *args, &content)
         opts = args.last.kind_of?(::Hash) ? args.pop : {}
         outvar = self.erb_outvar_name
@@ -35,8 +39,7 @@ module Deas::ErbTags
           instance_variable_set(outvar, orig_outvar)
         end
 
-        tag_markup = tag(name, "#{captured_content}\n", opts)
-        instance_variable_get(outvar) << "#{tag_markup}\n"
+        self.capture tag(name, "#{captured_content}\n", opts)
       end
 
     end

--- a/lib/deas-erbtags/capture_tag.rb
+++ b/lib/deas-erbtags/capture_tag.rb
@@ -4,16 +4,24 @@ module Deas::ErbTags
   module CaptureTag
 
     def self.included(receiver)
-      receiver.class_eval{ include Tag, Method }
+      receiver.class_eval{ include Tag, Methods }
     end
 
-    module Method
+    module Methods
+
+      def erb_outvar_name
+        self.sinatra_call.settings.erb[:outvar]
+      end
+
+      def erb_outvar
+        instance_variable_get(self.erb_outvar_name)
+      end
 
       def capture_tag(name, *args, &content)
         opts = args.last.kind_of?(::Hash) ? args.pop : {}
-        outvar = self.sinatra_call.settings.erb[:outvar]
+        outvar = self.erb_outvar_name
         captured_content = begin
-          orig_outvar = instance_variable_get(outvar)
+          orig_outvar = self.erb_outvar
           instance_variable_set(outvar, "\n")
 
           result = instance_eval(&content) if !content.nil?

--- a/lib/deas-erbtags/link_to.rb
+++ b/lib/deas-erbtags/link_to.rb
@@ -1,11 +1,11 @@
 require 'deas-erbtags/tag'
-require 'deas-erbtags/capture_tag'
+require 'deas-erbtags/capture'
 
 module Deas::ErbTags
   module LinkTo
 
     def self.included(receiver)
-      receiver.class_eval{ include Tag, CaptureTag, Method }
+      receiver.class_eval{ include Tag, Capture, Method }
     end
 
     module Method

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -26,6 +26,10 @@ module Factory
         [args, block].inspect
       end
 
+      def partial(*args, &block)
+        [args, block].inspect
+      end
+
     end
 
     template_class.new

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -21,6 +21,11 @@ module Factory
           })
         })
       end
+
+      def render(*args, &block)
+        [args, block].inspect
+      end
+
     end
 
     template_class.new

--- a/test/unit/capture_tag_tests.rb
+++ b/test/unit/capture_tag_tests.rb
@@ -11,7 +11,7 @@ module Deas::ErbTags::CaptureTag
     end
     subject{ @template }
 
-    should have_imeth :capture_tag
+    should have_imeths :erb_outvar_name, :erb_outvar, :capture_tag
 
     should "include the `Tag` module" do
       assert_includes Deas::ErbTags::Tag, subject.class.included_modules

--- a/test/unit/capture_tests.rb
+++ b/test/unit/capture_tests.rb
@@ -11,7 +11,8 @@ module Deas::ErbTags::Capture
     end
     subject{ @template }
 
-    should have_imeths :erb_outvar_name, :erb_outvar, :capture_tag
+    should have_imeths :erb_outvar_name, :erb_outvar
+    should have_imeths :capture, :capture_tag
 
     should "include the `Tag` module" do
       assert_includes Deas::ErbTags::Tag, subject.class.included_modules

--- a/test/unit/capture_tests.rb
+++ b/test/unit/capture_tests.rb
@@ -12,7 +12,7 @@ module Deas::ErbTags::Capture
     subject{ @template }
 
     should have_imeths :erb_outvar_name, :erb_outvar
-    should have_imeths :capture, :capture_tag, :capture_render
+    should have_imeths :capture, :capture_tag, :capture_render, :capture_partial
 
     should "include the `Tag` module" do
       assert_includes Deas::ErbTags::Tag, subject.class.included_modules
@@ -58,6 +58,19 @@ module Deas::ErbTags::Capture
       assert_empty subject._out_buf
 
       cap_output = subject.capture_render('something')
+      assert_equal exp_output, cap_output
+      assert_equal exp_output, subject._out_buf
+    end
+
+  end
+
+  class CapturePartialTests < BaseTests
+
+    should "capture output from Deas' template `partial` call" do
+      exp_output = "#{subject.partial('something')}\n"
+      assert_empty subject._out_buf
+
+      cap_output = subject.capture_partial('something')
       assert_equal exp_output, cap_output
       assert_equal exp_output, subject._out_buf
     end

--- a/test/unit/capture_tests.rb
+++ b/test/unit/capture_tests.rb
@@ -12,11 +12,15 @@ module Deas::ErbTags::Capture
     subject{ @template }
 
     should have_imeths :erb_outvar_name, :erb_outvar
-    should have_imeths :capture, :capture_tag
+    should have_imeths :capture, :capture_tag, :capture_render
 
     should "include the `Tag` module" do
       assert_includes Deas::ErbTags::Tag, subject.class.included_modules
     end
+
+  end
+
+  class CaptureTagTests < BaseTests
 
     should "create content by capturing content from a given block" do
       div_div = subject.tag(:div, "\n#{subject.tag(:div, "\ninner\n")}\n\n", {
@@ -43,6 +47,19 @@ module Deas::ErbTags::Capture
     should "create empty tags if no block given" do
       empty_div = subject.tag(:div, "\n\n", :id => 'outer') + "\n"
       assert_equal empty_div, subject.capture_tag(:div, :id => 'outer')
+    end
+
+  end
+
+  class CaptureRenderTests < BaseTests
+
+    should "capture output from Deas' template `render` call" do
+      exp_output = "#{subject.render('something')}\n"
+      assert_empty subject._out_buf
+
+      cap_output = subject.capture_render('something')
+      assert_equal exp_output, cap_output
+      assert_equal exp_output, subject._out_buf
     end
 
   end

--- a/test/unit/capture_tests.rb
+++ b/test/unit/capture_tests.rb
@@ -1,13 +1,13 @@
 require 'assert'
 require 'deas-erbtags/tag'
-require 'deas-erbtags/capture_tag'
+require 'deas-erbtags/capture'
 
-module Deas::ErbTags::CaptureTag
+module Deas::ErbTags::Capture
 
   class BaseTests < Assert::Context
-    desc "the `CaptureTag` module"
+    desc "the `Capture` module"
     setup do
-      @template = Factory.template(Deas::ErbTags::CaptureTag)
+      @template = Factory.template(Deas::ErbTags::Capture)
     end
     subject{ @template }
 

--- a/test/unit/deas-erbtags_tests.rb
+++ b/test/unit/deas-erbtags_tests.rb
@@ -14,7 +14,7 @@ module Deas::ErbTags
 
     should "include all of the individual modules" do
       exp_modules = [
-        Tag, CaptureTag, LinkTo, MailTo, ImageTag
+        Tag, Capture, LinkTo, MailTo, ImageTag
       ]
 
       exp_modules.each do |m|

--- a/test/unit/link_to_tests.rb
+++ b/test/unit/link_to_tests.rb
@@ -1,6 +1,6 @@
 require 'assert'
 require 'deas-erbtags/tag'
-require 'deas-erbtags/capture_tag'
+require 'deas-erbtags/capture'
 require 'deas-erbtags/link_to'
 
 module Deas::ErbTags::LinkTo
@@ -18,8 +18,8 @@ module Deas::ErbTags::LinkTo
       assert_includes Deas::ErbTags::Tag, subject.class.included_modules
     end
 
-    should "include the `CaptureTag` module" do
-      assert_includes Deas::ErbTags::CaptureTag, subject.class.included_modules
+    should "include the `Capture` module" do
+      assert_includes Deas::ErbTags::Capture, subject.class.included_modules
     end
 
     should "create an anchor tag with no content or href" do


### PR DESCRIPTION
This does a few different things:  
- rename `CaptureTag` to the more generic `Capture` since it will be doing more than just tag handling.
- add `erb_outvar_name` and `erb_outvar` for accessing outvar info
- add `capture` that takes "captured content" and adds it to the outvar
- update `capture_tag` to use these formal methods internally (and implicitly test them)
- add `capture_render` which proxies a Deas template `render` call, captures its output, and adds it to the outvar.
- add `capture_partial` which proxies a Deas template `partial` call, captures its output, and adds it to the outvar.

This is all to provide a more rich capture API to allow users to do complex renders in their ERB templates.

@jcredding ready for review.
