### PR TITLE
allow specifying an alternat `link_to` tag

### DIFF
--- a/lib/deas-erbtags/link_to.rb
+++ b/lib/deas-erbtags/link_to.rb
@@ -17,11 +17,12 @@ module Deas::ErbTags
           args.last
         ]
         opts.update(:href => href.to_s) if !href.nil?
+        tag = opts.delete(:tag) || opts.delete('tag') || :a
 
         if block_given?
-          capture_tag(:a, opts, &block)
+          capture_tag(tag, opts, &block)
         else
-          tag(:a, content || href, opts)
+          tag(tag, content || href, opts)
         end
       end
 

--- a/test/unit/link_to_tests.rb
+++ b/test/unit/link_to_tests.rb
@@ -55,6 +55,17 @@ module Deas::ErbTags::LinkTo
       assert_equal exp, subject.link_to('www.google.com'){ span }
     end
 
+    should "create a link using a tag other than the anchor tag" do
+      href_content = subject.tag(:button, 'google', {:href => 'www.google.com'})
+
+      assert_equal href_content, subject.link_to('google', 'www.google.com', {
+        :tag => 'button'
+      })
+      assert_equal href_content, subject.link_to('google', 'www.google.com', {
+        'tag' => 'button'
+      })
+    end
+
   end
 
 end


### PR DESCRIPTION
This allows the link_to helper to take an additional option, `:tag`,
and use its value as the generated html tag value.  It defaults to
`:a` of course to be backwards compatible with its previous behavior.

@jcredding ready for review.
