### PR TITLE
update capture template methods to properly capture nested content

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ template_helpers(Deas::ErbTags::Capture)
 
 The `capture_render` method is used to make Deas template `render` calls with nested erb markup.  It calls `render` with the given args, and captures its output.  Call it just as you would `render`, just invoke the call using `<% ... %>`.
 
-### `capture_render`
+### `capture_partial`
 
 ```ruby
 template_helpers(Deas::ErbTags::Capture)

--- a/deas-tags.gemspec
+++ b/deas-tags.gemspec
@@ -17,6 +17,8 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_development_dependency("assert")
+  gem.add_dependency("deas", ["~> 0.23"])
+
+  gem.add_development_dependency("assert", ["~> 2.3"])
 
 end

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -23,11 +23,13 @@ module Factory
       end
 
       def render(*args, &block)
-        [args, block].inspect
+        cap_content = "#{(block || Proc.new {}).call}"
+        RenderArgs.new(args, cap_content).inspect
       end
 
       def partial(*args, &block)
-        [args, block].inspect
+        cap_content = "#{(block || Proc.new {}).call}"
+        RenderArgs.new(args, cap_content).inspect
       end
 
     end
@@ -38,5 +40,7 @@ module Factory
   def self.html_attrs(opts)
     Deas::ErbTags::Utils.html_attrs(opts)
   end
+
+  RenderArgs = Struct.new(:args, :captured_content)
 
 end

--- a/test/unit/capture_tests.rb
+++ b/test/unit/capture_tests.rb
@@ -4,14 +4,14 @@ require 'deas-erbtags/capture'
 
 module Deas::ErbTags::Capture
 
-  class BaseTests < Assert::Context
+  class UnitTests < Assert::Context
     desc "the `Capture` module"
     setup do
       @template = Factory.template(Deas::ErbTags::Capture)
     end
     subject{ @template }
 
-    should have_imeths :erb_outvar_name, :erb_outvar
+    should have_imeths :erb_outvar_name, :erb_outvar, :erb_write
     should have_imeths :capture, :capture_tag, :capture_render, :capture_partial
 
     should "include the `Tag` module" do
@@ -20,7 +20,7 @@ module Deas::ErbTags::Capture
 
   end
 
-  class CaptureTagTests < BaseTests
+  class CaptureTagTests < UnitTests
 
     should "create content by capturing content from a given block" do
       div_div = subject.tag(:div, "\n#{subject.tag(:div, "\ninner\n")}\n\n", {
@@ -51,28 +51,32 @@ module Deas::ErbTags::Capture
 
   end
 
-  class CaptureRenderTests < BaseTests
+  class CaptureRenderTests < UnitTests
 
     should "capture output from Deas' template `render` call" do
-      exp_output = "#{subject.render('something')}\n"
       assert_empty subject._out_buf
 
-      cap_output = subject.capture_render('something')
-      assert_equal exp_output, cap_output
-      assert_equal exp_output, subject._out_buf
+      content = Proc.new{ '_some_content_' }
+      exp_out = "#{subject.render('something', &Proc.new{ subject.capture(&content) })}\n"
+      cap_out = subject.capture_render('something') { '_some_content_' }
+
+      assert_equal exp_out, cap_out
+      assert_equal exp_out, subject._out_buf
     end
 
   end
 
-  class CapturePartialTests < BaseTests
+  class CapturePartialTests < UnitTests
 
     should "capture output from Deas' template `partial` call" do
-      exp_output = "#{subject.partial('something')}\n"
       assert_empty subject._out_buf
 
-      cap_output = subject.capture_partial('something')
-      assert_equal exp_output, cap_output
-      assert_equal exp_output, subject._out_buf
+      content = Proc.new{ }
+      exp_out = "#{subject.partial('something', &Proc.new{ subject.capture(&content) })}\n"
+      cap_out = subject.capture_partial('something')
+
+      assert_equal exp_out, cap_out
+      assert_equal exp_out, subject._out_buf
     end
 
   end


### PR DESCRIPTION
This updates the `capture_*` methods to all have a similar implementations
and all capture any nested block content using the same approach.
This renames the prev `capture` method to be `erb_write` as this
is a more appropriate name.

This updates the tests to make them more readable and to make them
fully test the nested block content behavior.

@jcredding ready for review.
